### PR TITLE
fix: remediate security review findings

### DIFF
--- a/Invoke-NetworkDiagnostics.ps1
+++ b/Invoke-NetworkDiagnostics.ps1
@@ -47,6 +47,7 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 $repoRoot = $PSScriptRoot
+$script:MaxWorkflowProfileBytes = 1MB
 
 function Resolve-ArtifactRoot {
   param([string]$Path)
@@ -72,6 +73,10 @@ function Import-WorkflowProfile {
   }
   if (-not (Test-Path -LiteralPath $resolvedPath -PathType Leaf)) {
     throw "ProfilePath is not a file: $resolvedPath"
+  }
+  $profileInfo = Get-Item -LiteralPath $resolvedPath
+  if ($profileInfo.Length -gt $script:MaxWorkflowProfileBytes) {
+    throw "ProfilePath exceeds maximum size (1 MB): $resolvedPath"
   }
 
   $parsed = Get-Content -LiteralPath $resolvedPath -Raw -Encoding UTF8 | ConvertFrom-Json -AsHashtable

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,3 +4,48 @@
 - Treat saved throughput reports and Windows tuning backups as sensitive operational data.
 - Report security issues privately through the repository security contact or a private channel.
 - Do not attach registry backups, `Get-NetQosPolicy` exports, or raw route traces to public issues unless sanitized.
+
+## Defensive Review Notes
+
+### Repo Index
+
+- `Invoke-NetworkDiagnostics.ps1`: umbrella workflow dispatcher; merges profile defaults with CLI input and runs child PowerShell entrypoints in isolated processes.
+- `apps/path/` and `src/powershell/path/`: Windows path diagnostics over `ping`, `tracert`, `pathping`, `Test-NetConnection`, and best-effort UDP/TCP probes.
+- `apps/path/mtr-test-suite.sh` and `src/bash/path/`: Bash/MTR path diagnostics with host/config/path validation.
+- `apps/throughput/` and `src/powershell/throughput/`: `iperf3` throughput tests, saved profiles, result reports, and run indexes.
+- `apps/windows-tuning/` and `src/powershell/windows-tuning/`: optional Windows QoS/NIC/power-plan tuning with backup and restore.
+- `scripts/`: local CI, PowerShell quality gates, helper functions, and lightweight secret scanning.
+- `tests/`: Bats and Pester unit, integration, smoke, and E2E coverage for operator workflows.
+
+### Threat Model
+
+- Auth boundary: no network service or login surface exists in this repo; authorization is local operator control and OS account privileges.
+- Input boundary: CLI parameters, JSON workflow profiles, throughput profile stores, `config/hosts.conf`, and environment-derived paths.
+- File boundary: artifacts, logs, throughput profile JSON, Windows tuning backup folders, registry exports, CSV, CLIXML, and run reports.
+- Network boundary: diagnostic targets are operator-supplied hosts passed to native tools; command invocation must stay argument-array based and reject shell/control characters.
+- Privilege boundary: Windows tuning restore/apply can require administrator rights and can modify registry, QoS, NIC, and power-plan state.
+
+### Findings
+
+| ID | Severity | Status | Evidence | Impact | Patch |
+| --- | --- | --- | --- | --- | --- |
+| NDS-SEC-001 | Medium | Fixed on `security/remediate-review-findings` | `Restore-UjState` previously continued when `backup_manifest.json` was missing or malformed; regression tests now cover both cases in `tests/windows-tuning/WindowsNetworkTuning.Tests.ps1`. | A local attacker or accidental operator error could point restore at an untrusted folder and trigger registry/QoS/NIC/power restore helpers without a validated suite manifest. | Restore now fails closed for every non-OK manifest status before any component restore helper runs. |
+| NDS-SEC-002 | Low | Fixed on `security/remediate-review-findings` | `Invoke-NetworkDiagnostics.ps1` read `-ProfilePath` with `Get-Content -Raw | ConvertFrom-Json` and no file-size limit. | A very large local profile could cause avoidable memory/CPU pressure during defensive tooling runs. | Workflow profiles now have a 1 MB cap before parsing, with Pester coverage for oversized files. |
+| NDS-SEC-003 | Low | Fixed on `security/remediate-review-findings` | `Open-FolderOrFile` passed output paths directly to platform openers; throughput `OutDir` validation did not reject leading-dash path names. | A local operator-supplied path that looks like an option could change opener behavior when `-OpenOutputFolder` is used. | Throughput `OutDir` rejects option-like paths, opener calls receive absolute paths, and classification stays input-validation. |
+
+### PR Summary
+
+Title: `fix: remediate security review findings`
+
+Summary:
+
+- Block Windows tuning restore when the backup manifest is missing, invalid, or incompatible.
+- Cap workflow profile size before JSON parsing.
+- Reject option-like throughput output paths and pass absolute paths to platform openers.
+- Document the current security review index, threat model, finding closure, and verification.
+
+Verification:
+
+- `pwsh -NoProfile -NonInteractive -Command "Invoke-Pester -Path ./tests/orchestration/Invoke-NetworkDiagnostics.Tests.ps1,./tests/throughput/Iperf3TestSuite.Tests.ps1,./tests/windows-tuning/WindowsNetworkTuning.Tests.ps1 -CI"`
+- `./scripts/ci-local.sh`
+- `git diff --check`

--- a/scripts/PathHelpers.ps1
+++ b/scripts/PathHelpers.ps1
@@ -59,19 +59,20 @@ function Open-FolderOrFile {
     [Parameter(Mandatory)]
     [string]$Path
   )
+  $openerPath = [System.IO.Path]::GetFullPath($Path)
   if ($IsWindows) {
-    Start-Process explorer.exe -ArgumentList @($Path)
+    Start-Process explorer.exe -ArgumentList @($openerPath)
   }
   elseif ($IsMacOS) {
-    Start-Process 'open' -ArgumentList @($Path)
+    Start-Process 'open' -ArgumentList @($openerPath)
   }
   else {
     $xdgOpen = Get-Command 'xdg-open' -ErrorAction SilentlyContinue
     if ($xdgOpen) {
-      Start-Process 'xdg-open' -ArgumentList @($Path)
+      Start-Process 'xdg-open' -ArgumentList @($openerPath)
     }
     else {
-      Write-Warning "No file opener found. Path: $Path"
+      Write-Warning "No file opener found. Path: $openerPath"
     }
   }
 }

--- a/src/powershell/throughput/Private/ConfigValidation.ps1
+++ b/src/powershell/throughput/Private/ConfigValidation.ps1
@@ -125,6 +125,7 @@ function ConvertTo-Iperf3KnownValue {
     'OutDir' {
       $s = ConvertTo-Iperf3NonEmptyString -Value $Value -Key 'OutDir'
       if ($s -match '[\x00-\x1f]') { throw "OutDir path contains control characters." }
+      if ($s.StartsWith('-')) { throw "OutDir path must not look like an option (starts with '-'): $s" }
       return $s
     }
     'ProfileName' { return (ConvertTo-Iperf3NonEmptyString -Value $Value -Key 'ProfileName') }

--- a/src/powershell/throughput/Private/ErrorClassification.ps1
+++ b/src/powershell/throughput/Private/ErrorClassification.ps1
@@ -24,7 +24,7 @@ function Resolve-Iperf3ClassifiedError {
   if (
     $ErrorRecord.Exception -is [System.Management.Automation.ParameterBindingException] -or
     $fqid -match 'ParameterArgumentValidationError|ParameterBinding' -or
-    $msg -match 'Cannot validate argument on parameter|Cannot bind parameter|Invalid value for key|Target is required|Invalid Target|ProfileName is required|Profile .+ not found|At least one DSCP class is required|Profiles file path must be under|Configuration path must be under|invalid characters|\.json extension|exceeds maximum length|control characters|Unknown parameter key|Invalid TCP window size|Invalid DSCP class|Unknown DSCP class'
+    $msg -match 'Cannot validate argument on parameter|Cannot bind parameter|Invalid value for key|Target is required|Invalid Target|ProfileName is required|Profile .+ not found|At least one DSCP class is required|Profiles file path must be under|Configuration path must be under|invalid characters|\.json extension|exceeds maximum length|control characters|must not look like an option|Unknown parameter key|Invalid TCP window size|Invalid DSCP class|Unknown DSCP class'
   ) {
     return [pscustomobject]@{
       ErrorId  = 'Iperf3TestSuite.InputValidation'

--- a/src/powershell/windows-tuning/WindowsUdpJitterOptimization/Private/Actions.BackupRestore.ps1
+++ b/src/powershell/windows-tuning/WindowsUdpJitterOptimization/Private/Actions.BackupRestore.ps1
@@ -596,12 +596,8 @@ function Restore-UjState {
   $manifestCheck = Read-UjBackupManifest -BackupFolder $BackupFolder
   if ($manifestCheck.Status -eq 'OK') {
     Write-UjInformation -Message ("Validated backup manifest (Timestamp: {0})" -f $manifestCheck.Manifest.Timestamp)
-  } elseif ($manifestCheck.Status -eq 'Missing') {
-    Write-Warning -Message 'No backup summary file found. The backup may be incomplete or from an older version of this tool. Restore will proceed but some components may be skipped.'
-  } elseif ($manifestCheck.Status -eq 'Invalid') {
-    Write-Warning -Message 'Could not read the backup summary file. The backup may still work, but some details could not be verified.'
   } else {
-    Write-Warning -Message $manifestCheck.Message
+    Write-Warning -Message ("Restore blocked: {0}" -f $manifestCheck.Message)
     return [ordered]@{
       Manifest    = 'Warn'
       Registry    = 'Skipped'

--- a/tests/orchestration/Invoke-NetworkDiagnostics.Tests.ps1
+++ b/tests/orchestration/Invoke-NetworkDiagnostics.Tests.ps1
@@ -80,6 +80,17 @@ Describe 'Invoke-NetworkDiagnostics orchestration' {
     ($output | Out-String) | Should -Match 'Protocols:\s+IPv4'
   }
 
+  It 'rejects oversized workflow profiles before parsing JSON' {
+    $profileFile = Join-Path $TestDrive 'oversized-profile.json'
+    Set-Content -LiteralPath $profileFile -Value ('x' * (1MB + 1)) -NoNewline -Encoding UTF8
+
+    $output = & pwsh -NoLogo -NoProfile -NonInteractive -File $script:InvokeNetworkDiagnosticsScriptPath `
+      -Workflow Path -ProfilePath $profileFile -DryRun 2>&1
+
+    $LASTEXITCODE | Should -Not -Be 0
+    ($output | Out-String) | Should -Match 'ProfilePath exceeds maximum size'
+  }
+
   It 'Triage skips throughput silently when IperfTarget is not provided' {
     $output = & pwsh -NoLogo -NoProfile -NonInteractive -File $script:InvokeNetworkDiagnosticsScriptPath `
       -Workflow Triage -DryRun 2>&1

--- a/tests/throughput/Iperf3TestSuite.Tests.ps1
+++ b/tests/throughput/Iperf3TestSuite.Tests.ps1
@@ -788,6 +788,12 @@ exit `$LASTEXITCODE
       }
     }
 
+    It 'rejects OutDir values that look like opener options' {
+      InModuleScope Iperf3TestSuite {
+        { ConvertTo-Iperf3KnownValue -Key 'OutDir' -Value '-reports' } | Should -Throw '*must not look like an option*'
+      }
+    }
+
     It 'accepts normal OutDir paths' {
       InModuleScope Iperf3TestSuite {
         $result = ConvertTo-Iperf3KnownValue -Key 'OutDir' -Value 'logs/output'
@@ -911,6 +917,15 @@ exit `$LASTEXITCODE
       }
     }
 
+    It 'classifies option-like paths as InputValidation' {
+      InModuleScope Iperf3TestSuite {
+        $ex = New-Object System.Exception("OutDir path must not look like an option (starts with '-'): -reports")
+        $er = New-Object System.Management.Automation.ErrorRecord($ex, 'test', 'NotSpecified', $null)
+        $result = Resolve-Iperf3ClassifiedError -ErrorRecord $er
+        $result.ErrorId | Should -Be 'Iperf3TestSuite.InputValidation'
+      }
+    }
+
     It 'classifies unmatched patterns as Internal with verbose output' {
       InModuleScope Iperf3TestSuite {
         $ex = New-Object System.Exception("Something completely unexpected happened.")
@@ -961,6 +976,23 @@ exit `$LASTEXITCODE
         $base = Join-Path $TestDrive 'sub'
         $outside = Join-Path $TestDrive 'other'
         Test-PathUnderBase -BasePath $base -CandidatePath $outside | Should -Be $false
+      }
+    }
+  }
+
+  Context 'Open-FolderOrFile' {
+    It 'passes an absolute path to platform openers' {
+      . (Join-Path $script:RepoRoot 'scripts/PathHelpers.ps1')
+      $relativePath = 'relative-output'
+      $expectedPath = [System.IO.Path]::GetFullPath($relativePath)
+
+      Mock -CommandName Get-Command { [pscustomobject]@{ Name = 'xdg-open' } }
+      Mock -CommandName Start-Process {}
+
+      Open-FolderOrFile -Path $relativePath
+
+      Assert-MockCalled -CommandName Start-Process -Times 1 -Exactly -ParameterFilter {
+        @($ArgumentList)[0] -eq $expectedPath
       }
     }
   }

--- a/tests/windows-tuning/WindowsNetworkTuning.Tests.ps1
+++ b/tests/windows-tuning/WindowsNetworkTuning.Tests.ps1
@@ -95,6 +95,39 @@ Describe 'Windows network tuning module' {
 
   Context 'Restore safety and reset scope' {
     InModuleScope WindowsUdpJitterOptimization {
+      It 'rejects missing backup manifests before restore work starts' {
+        $backupFolder = Join-Path $TestDrive 'missing-manifest-backup'
+        New-Item -ItemType Directory -Path $backupFolder -Force | Out-Null
+
+        Mock -CommandName Restore-UjRegistryFromBackup { throw 'should not run' }
+        Mock -CommandName Restore-UjQosFromBackup { throw 'should not run' }
+        Mock -CommandName Restore-UjNicFromBackup { throw 'should not run' }
+        Mock -CommandName Restore-UjRscFromBackup { throw 'should not run' }
+        Mock -CommandName Restore-UjPowerPlanFromBackup { throw 'should not run' }
+
+        $result = Restore-UjState -BackupFolder $backupFolder
+
+        $result['Manifest'] | Should -Be 'Warn'
+        $result['Registry'] | Should -Be 'Skipped'
+      }
+
+      It 'rejects invalid backup manifests before restore work starts' {
+        $backupFolder = Join-Path $TestDrive 'invalid-manifest-backup'
+        New-Item -ItemType Directory -Path $backupFolder -Force | Out-Null
+        Set-Content -LiteralPath (Join-Path $backupFolder 'backup_manifest.json') -Value '{' -Encoding UTF8
+
+        Mock -CommandName Restore-UjRegistryFromBackup { throw 'should not run' }
+        Mock -CommandName Restore-UjQosFromBackup { throw 'should not run' }
+        Mock -CommandName Restore-UjNicFromBackup { throw 'should not run' }
+        Mock -CommandName Restore-UjRscFromBackup { throw 'should not run' }
+        Mock -CommandName Restore-UjPowerPlanFromBackup { throw 'should not run' }
+
+        $result = Restore-UjState -BackupFolder $backupFolder
+
+        $result['Manifest'] | Should -Be 'Warn'
+        $result['Registry'] | Should -Be 'Skipped'
+      }
+
       It 'rejects incompatible backup manifests before restore work starts' {
         $backupFolder = Join-Path $TestDrive 'incompatible-backup'
         New-Item -ItemType Directory -Path $backupFolder -Force | Out-Null


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Security**
  * Added 1MB size limit for workflow profile files to prevent oversized inputs
  * Implemented stricter input validation to reject option-like output directory paths
  * Enhanced restore safety with fail-closed behavior when backup manifest is missing or invalid

* **Bug Fixes**
  * Improved file/folder path resolution to use canonical absolute paths consistently

* **Documentation**
  * Updated security documentation with threat model and resolved findings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->