### PR TITLE
Improve Windows dry-run readiness

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+* text=auto eol=lf
+
+*.7z binary
+*.dll binary
+*.exe binary
+*.gif binary
+*.gz binary
+*.ico binary
+*.jpeg binary
+*.jpg binary
+*.pdf binary
+*.png binary
+*.pdb binary
+*.zip binary

--- a/README.md
+++ b/README.md
@@ -32,7 +32,13 @@ pwsh -File .\Invoke-NetworkDiagnostics.ps1 -Workflow WindowsTuning -TuningAction
 
 ## Verification
 
-Local suite:
+Prerequisite readiness check, no installs:
+
+```powershell
+pwsh -File .\scripts\Test-Prerequisites.ps1
+```
+
+Local suite, no dependency installs:
 
 ```bash
 ./scripts/ci-local.sh
@@ -43,6 +49,19 @@ PowerShell-only checks:
 ```powershell
 pwsh -File .\scripts\ci.ps1
 ```
+
+PowerShell-only checks without installing missing modules:
+
+```powershell
+pwsh -File .\scripts\ci.ps1 -NoInstall
+```
+
+Windows notes:
+
+- The Bash and Bats files are pinned to LF line endings through `.gitattributes` so WSL Bash can parse them from a Windows checkout.
+- `scripts\ci.ps1` installs the pinned PowerShell test modules when they are missing unless `-NoInstall` is used.
+- Use `pwsh -File .\scripts\Test-Prerequisites.ps1 -IncludeIperf3` when validating a host for real throughput runs.
+- `iPerf3Test.ps1 -WhatIf`, `NetPathSuite.ps1 -DryRun`, and Windows tuning `-DryRun` are the safe preview modes; real throughput and path runs can perform network probes.
 
 ## Layout
 

--- a/docs/windows-dry-run-readiness.md
+++ b/docs/windows-dry-run-readiness.md
@@ -1,0 +1,95 @@
+# Windows Dry-Run Readiness Review
+
+Review date: 2026-05-11
+
+This companion report records a safe Windows dry-run pass for the network diagnostics suite. The scripts were originally authored on macOS but target Windows operators, so this review focuses on local Windows checkout behavior, non-mutating dry-run commands, and fix proposals. No system dependencies were installed, no tuning changes were applied, and no real network probes were run. Temporary test dependencies used for verification were isolated under the ignored `.cache/` directory.
+
+## Implementation Status
+
+The follow-up fix pass implemented the highest-value items from this review:
+
+- Added `.gitattributes` rules to keep text files checked out with LF endings, matching `.editorconfig`.
+- Renormalized tracked text files to LF.
+- Added `scripts/Test-Prerequisites.ps1` for non-mutating readiness checks.
+- Added `scripts/ci.ps1 -NoInstall` to prevent module installation during PowerShell validation.
+- Updated README verification notes for Windows and dry-run usage.
+- Suppressed unselected protocol host summaries in path dry-run output.
+- Updated local test scripts so safe verification does not require unavailable submodules, does not scan ignored dependency caches, and imports the requested Pester version before using Pester 5 types.
+
+## Environment Snapshot
+
+| Item | Observed state |
+| --- | --- |
+| Repository state before documentation | `main...origin/main`, clean |
+| Host shell | Windows PowerShell launching commands from `C:\Users\sebastian\Desktop\git\network-diagnostics-suite` |
+| PowerShell | `pwsh` available at `C:\Program Files\WindowsApps\Microsoft.PowerShell_7.6.1.0_x64__8wekyb3d8bbwe\pwsh.exe` |
+| Bash | WSL launcher available at `C:\Windows\system32\bash.exe` |
+| Initial missing CLI tools on PATH | `shellcheck`, `bats`, `iperf3` |
+| Initial PowerShell modules | `PSScriptAnalyzer` not installed; `Pester 3.4.0` installed, but repo CI expects `Pester 5.7.1` |
+| Line ending policy | `.editorconfig` requires `end_of_line = lf` |
+| Initial Git line ending state | Bash-related files were indexed as LF but checked out as CRLF (`git ls-files --eol`) |
+| Git attributes | `.gitattributes` now enforces LF for text files and marks common binary extensions as binary |
+
+## Initial Safe Dry-Run Results
+
+| Command | Exit code | Safety notes | Result summary |
+| --- | ---: | --- | --- |
+| `pwsh -NoProfile -NonInteractive -File .\apps\path\NetPathSuite.ps1 -DryRun -Protocols IPv4 -Rounds Standard -HostsIPv4 example.com -LogDirectory .\artifacts\dryrun-path` | 0 | Uses the script's dry-run mode; no probes executed and no output files created. | Planned 1 IPv4 `Standard` run for `example.com`; announced would-be JSON/CSV paths. |
+| `pwsh -NoProfile -NonInteractive -File .\apps\throughput\iPerf3Test.ps1 -Target example.com -WhatIf -SkipReachabilityCheck -DisableMtuProbe -OutDir .\artifacts\dryrun-throughput` | 0 | Uses `-WhatIf`, skips reachability and MTU probes; does not require `iperf3` execution. | Reported approximately 1110 planned tests and would-be CSV/JSON paths. |
+| `pwsh -NoProfile -NonInteractive -File .\apps\windows-tuning\Optimize-NetworkPath.ps1 -Action Apply -TuningProfile Safe -DryRun -SkipAdminCheck -PassThru` | 0 | Uses `-DryRun` and skips admin check; no registry, QoS, backup, or power-plan writes. | Returned `Success = True`; components were marked skipped. |
+| `pwsh -NoProfile -NonInteractive -File .\Invoke-NetworkDiagnostics.ps1 -Workflow Triage -DryRun -Protocols IPv4 -Rounds Standard -HostsIPv4 example.com -OutRoot .\artifacts\dryrun-orchestration` | 0 | Orchestrates the path dry run in an isolated child PowerShell process. | Planned 1 path run and announced would-be artifact paths under `artifacts/dryrun-orchestration/path`. |
+| `bash -n scripts/ci-local.sh` | 1 | Syntax-only Bash parse; no script body execution. | Failed with `syntax error: unexpected end of file`, consistent with CRLF checkout. |
+| `bash -n scripts/install-test-deps.sh` | 0 | Syntax-only Bash parse; no submodule or dependency action. | Parsed successfully despite CRLF checkout. |
+| `bash -n scripts/run-workflow.sh` | 1 | Syntax-only Bash parse; no workflow execution. | Failed with `syntax error: unexpected end of file`, consistent with CRLF checkout. |
+| `bash -n apps/path/mtr-test-suite.sh` | 1 | Syntax-only Bash parse; no diagnostics executed. | Failed near `usage() {` with a visible carriage return token. |
+| PowerShell AST parse across `*.ps1`, `*.psm1`, and `*.psd1` | 0 | Parser-only validation; no scripts executed. | Parsed 67 PowerShell files with no syntax errors. |
+
+## Initial Issues And Fix Proposals
+
+| Severity | Area | Reproduction | Impact | Proposed fix |
+| --- | --- | --- | --- | --- |
+| High | Bash line endings on Windows checkout | `bash -n apps/path/mtr-test-suite.sh` | WSL Bash cannot parse several Bash entrypoints when the Windows working tree uses CRLF. | Add `.gitattributes` rules for `*.sh`, `*.bash`, and `*.bats` with `text eol=lf`, then renormalize affected files. |
+| High | Local CI dependency clarity | `Get-Command shellcheck,bats,iperf3` | Local verification fails or is skipped depending on which tools are installed; operators do not get a single non-mutating readiness report. | Add a prerequisite check script or `-CheckPrerequisites` mode that reports missing tools without installing anything. |
+| Medium | PowerShell module readiness | `pwsh -File .\scripts\Invoke-Tests.ps1` | `Invoke-Tests.ps1` fails because only legacy `Pester 3.4.0` is installed; `PSScriptAnalyzer` is absent. | Document Windows setup commands and/or add a non-mutating module check before running test scripts. |
+| Medium | `scripts/ci.ps1` side effects | Inspect `scripts/ci.ps1` or run only with installation approved. | The script installs exact module versions when missing, so it is not a pure dry-run validation command. | Split dependency installation from validation or add an explicit no-install mode. |
+| Low | Path dry-run summary noise | Run path dry run with `-Protocols IPv4`. | Summary still prints configured IPv6 hosts even though no IPv6 runs are selected. | Suppress unselected protocol host summaries or label them as configured-but-unused. |
+| Low | Platform-specific setup docs | Compare README local suite instructions with Windows tool availability. | `./scripts/ci-local.sh` is advertised as the local suite but assumes Unix tooling and LF checkout behavior. | Add separate Windows local setup and macOS/Linux setup notes. |
+
+## Prioritized Fix Proposals
+
+1. Add `.gitattributes` with LF enforcement for Bash and Bats files, then renormalize the affected files. This is the smallest change that addresses the immediate Windows checkout breakage.
+2. Add a non-mutating readiness check for required tools and modules: `pwsh`, `bash`, `git`, `shellcheck`, `bats`, `iperf3`, `Pester 5.7.1`, and `PSScriptAnalyzer 1.24.0`.
+3. Document Windows local verification separately from macOS/Linux verification, including the distinction between dry runs, dependency installation, and real network probes.
+4. Consider a `scripts/ci.ps1` no-install mode so users can validate readiness without modifying their PowerShell module environment.
+5. Clean up path dry-run output so protocol-specific runs only print host summaries relevant to the selected protocol.
+
+## Follow-Up Verification
+
+After implementing line-ending fixes, re-run:
+
+```powershell
+bash -n scripts/ci-local.sh
+bash -n scripts/install-test-deps.sh
+bash -n scripts/run-workflow.sh
+bash -n apps/path/mtr-test-suite.sh
+```
+
+After implementing dependency setup or a readiness checker, verify it reports missing tools without installing them unless explicitly requested.
+
+Run the repo's intended full CI only after dependency installation is approved, or use `scripts/ci.ps1 -NoInstall` to validate with already-available modules.
+
+## Final Safe Verification
+
+The final pass used ignored sandbox dependencies under `.cache/` and did not install global/system tools, perform Windows tuning writes, or run real diagnostics probes.
+
+| Check | Result |
+| --- | --- |
+| `pwsh -File .\scripts\Test-Prerequisites.ps1` with sandbox `PATH` and `PSModulePath` | Pass |
+| `pwsh -File .\scripts\ci.ps1 -NoInstall` | Pass; Pester 5.7.1 reported 212 passed, 0 failed, 3 skipped |
+| `.\scripts\ci-local.sh` via Git Bash with sandbox `shellcheck` and `bats` | Pass; delegates to `scripts/ci.ps1 -NoInstall` |
+| `pwsh -File .\scripts\Invoke-QualityGates.ps1` with sandbox `PSModulePath` | Pass; delegates to `scripts/ci.ps1 -NoInstall` |
+| Safe PowerShell app dry runs: path, throughput `-WhatIf`, Windows tuning `-DryRun`, orchestration triage `-DryRun` | Pass |
+| Safe Bash dry runs: `scripts/install-test-deps.sh`, `scripts/run-workflow.sh`, `apps/path/mtr-test-suite.sh --dry-run` | Pass |
+| Git line ending check for CRLF working-tree files after normalization | Pass; no `w/crlf` entries remain |
+
+Remaining out-of-scope validation: real `iperf3` throughput runs, real path probes, and non-dry-run Windows tuning were intentionally not executed because they mutate the host or network state.

--- a/scripts/Invoke-QualityGates.ps1
+++ b/scripts/Invoke-QualityGates.ps1
@@ -5,4 +5,4 @@ $ErrorActionPreference = 'Stop'
 
 $repoRoot = Split-Path -Parent $PSScriptRoot
 
-& (Join-Path $repoRoot 'scripts/ci.ps1')
+& (Join-Path $repoRoot 'scripts/ci.ps1') -NoInstall

--- a/scripts/Invoke-SecretScan.ps1
+++ b/scripts/Invoke-SecretScan.ps1
@@ -38,14 +38,32 @@ $patterns = @(
 $hitCount = 0
 $selfName = [System.IO.Path]::GetFileName($MyInvocation.MyCommand.Path)
 $binaryExts = @('.exe','.dll','.zip','.gz','.tar','.png','.jpg','.gif','.ico','.woff','.woff2','.ttf','.eot','.pdf')
-$files = Get-ChildItem -LiteralPath $Path -Recurse -File -Force -ErrorAction SilentlyContinue |
-  Where-Object {
-    $full = $_.FullName
-    $parts = $full.Split([IO.Path]::DirectorySeparatorChar)
-    $parts -notcontains '.git' -and
-      $_.Name -ne $selfName -and
+$resolvedPath = [System.IO.Path]::GetFullPath($Path)
+$gitDir = Join-Path $resolvedPath '.git'
+
+if ((Test-Path -LiteralPath $gitDir) -and (Get-Command -Name git -ErrorAction SilentlyContinue)) {
+  $trackedPaths = & git -C $resolvedPath ls-files -z
+  $files = @($trackedPaths -split "`0" | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | ForEach-Object {
+      $candidate = Join-Path $resolvedPath $_
+      if (Test-Path -LiteralPath $candidate -PathType Leaf) {
+        Get-Item -LiteralPath $candidate
+      }
+    })
+} else {
+  $files = Get-ChildItem -LiteralPath $resolvedPath -Recurse -File -Force -ErrorAction SilentlyContinue |
+    Where-Object {
+      $full = $_.FullName
+      $parts = $full.Split([IO.Path]::DirectorySeparatorChar)
+      $parts -notcontains '.git' -and
+        $parts -notcontains '.cache' -and
+        $parts -notcontains 'artifacts'
+    }
+}
+
+$files = @($files | Where-Object {
+    $_.Name -ne $selfName -and
       $_.Extension -notin $binaryExts
-  }
+  })
 
 foreach ($pattern in $patterns) {
   $hits = $files | Select-String -Pattern $pattern

--- a/scripts/Invoke-Tests.ps1
+++ b/scripts/Invoke-Tests.ps1
@@ -14,6 +14,8 @@ if (-not (Get-Module -ListAvailable -Name Pester | Where-Object { $_.Version -ge
   exit 1
 }
 
+Import-Module -Name Pester -MinimumVersion 5.0.0 -ErrorAction Stop
+
 $config = [PesterConfiguration]::Default
 $config.Run.Path = $testsDir
 $config.Run.Exit = $true

--- a/scripts/Test-Prerequisites.ps1
+++ b/scripts/Test-Prerequisites.ps1
@@ -1,0 +1,62 @@
+<#
+.SYNOPSIS
+  Reports local tool and module readiness without installing anything.
+#>
+[CmdletBinding()]
+param(
+  [switch]$IncludeIperf3
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$requiredModules = @{
+  PSScriptAnalyzer = '1.24.0'
+  Pester           = '5.7.1'
+}
+
+$requiredCommands = @('pwsh', 'bash', 'git', 'shellcheck', 'bats')
+if ($IncludeIperf3) {
+  $requiredCommands += 'iperf3'
+}
+
+$results = New-Object System.Collections.Generic.List[object]
+
+foreach ($commandName in $requiredCommands) {
+  $command = Get-Command -Name $commandName -ErrorAction SilentlyContinue
+  $results.Add([pscustomobject]@{
+    Type     = 'Command'
+    Name     = $commandName
+    Required = 'present'
+    Found    = [bool]$command
+    Version  = if ($command -and $command.Version) { $command.Version.ToString() } else { '' }
+    Path     = if ($command) { $command.Source } else { '' }
+  })
+}
+
+foreach ($entry in $requiredModules.GetEnumerator() | Sort-Object Key) {
+  $module = Get-Module -ListAvailable -Name $entry.Key |
+    Where-Object { $_.Version -eq [version]$entry.Value } |
+    Select-Object -First 1
+
+  $newestModule = Get-Module -ListAvailable -Name $entry.Key |
+    Sort-Object Version -Descending |
+    Select-Object -First 1
+
+  $results.Add([pscustomobject]@{
+    Type     = 'PowerShellModule'
+    Name     = $entry.Key
+    Required = $entry.Value
+    Found    = [bool]$module
+    Version  = if ($module) { $module.Version.ToString() } elseif ($newestModule) { "found $($newestModule.Version)" } else { '' }
+    Path     = if ($module) { $module.Path } elseif ($newestModule) { $newestModule.Path } else { '' }
+  })
+}
+
+$results | Format-Table -AutoSize
+
+$missing = @($results | Where-Object { -not $_.Found })
+if ($missing.Count -gt 0) {
+  [Console]::Error.WriteLine("Missing prerequisite(s): $($missing.Name -join ', ')")
+  exit 1
+}

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -26,4 +26,4 @@ else
   echo "bats not found. Skipping Bash test suite." >&2
 fi
 
-pwsh -NoProfile -NonInteractive -File "$REPO_ROOT/scripts/ci.ps1"
+pwsh -NoProfile -NonInteractive -File "$REPO_ROOT/scripts/ci.ps1" -NoInstall

--- a/scripts/ci.ps1
+++ b/scripts/ci.ps1
@@ -1,3 +1,8 @@
+[CmdletBinding()]
+param(
+  [switch]$NoInstall
+)
+
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
@@ -25,6 +30,11 @@ function Test-ExactModuleInstalled {
 $missingModules = @(
   $requiredModules.GetEnumerator() | Where-Object { -not (Test-ExactModuleInstalled -Name $_.Key -Version $_.Value) }
 )
+
+if ($NoInstall -and $missingModules.Count -gt 0) {
+  [Console]::Error.WriteLine("Missing required PowerShell module(s): $($missingModules.Key -join ', '). Re-run without -NoInstall to install them, or install them manually.")
+  exit 1
+}
 
 if ($missingModules.Count -eq 0) {
   Write-Information 'Required PowerShell modules already available; skipping installation.' -InformationAction Continue

--- a/scripts/install-test-deps.sh
+++ b/scripts/install-test-deps.sh
@@ -3,8 +3,12 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 
-echo "Initializing test submodules..."
-git submodule update --init --recursive tests/bats tests/helpers/bats-support tests/helpers/bats-assert
+if [[ -f .gitmodules ]] && git config -f .gitmodules --get-regexp '^submodule\..*\.path$' >/dev/null 2>&1; then
+	echo "Initializing test submodules..."
+	git submodule update --init --recursive
+else
+	echo "No test submodules are configured; skipping submodule initialization."
+fi
 
-echo "Test dependencies installed."
-echo "Run tests with: tests/bats/bin/bats tests/"
+echo "Install shellcheck and bats with your platform package manager, or provide them on PATH."
+echo "Run tests with: bats tests/path"


### PR DESCRIPTION
## Summary
- Add Windows dry-run readiness documentation and non-mutating prerequisite checks
- Add LF checkout policy for text files and safer no-install validation paths
- Improve local dry-run and verification behavior for Windows-oriented workflows

## Verification
- prerequisite check
- PowerShell quality gates with no-install mode
- Bash local CI with no-install mode
- secret scan
- Bash syntax checks
- PowerShell AST parse
- safe PowerShell and Bash dry-runs
- whitespace and line-ending checks

Real throughput probes, real path probes, and non-dry-run Windows tuning were not run because they mutate host or network state.